### PR TITLE
fixups for new gcc version

### DIFF
--- a/src/config_shared.c
+++ b/src/config_shared.c
@@ -44,6 +44,8 @@
 #include "language.h"
 #include "libdspam.h"
 
+config_t agent_config;
+
 attribute_t _ds_find_attribute(config_t config, const char *key) {
   int i;
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -69,6 +69,11 @@
 #include "buffer.h"
 #include "language.h"
 
+int __daemon_run;	/* should we keep running? */
+int __num_threads;	/* number of live threads */
+int __hup;		/* should we reload? */
+pthread_mutex_t __lock;	/* global var lock */
+
 /*
  * daemon_listen(DRIVER_CTX *DTX)
  *

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -42,10 +42,10 @@
 
 #ifdef DAEMON
 
-int __daemon_run;	/* should we keep running? */
-int __num_threads;	/* number of live threads */
-int __hup;		/* should we reload? */
-pthread_mutex_t __lock;	/* global var lock */
+extern int __daemon_run;	/* should we keep running? */
+extern int __num_threads;	/* number of live threads */
+extern int __hup;		/* should we reload? */
+extern pthread_mutex_t __lock;	/* global var lock */
 
 typedef struct {
   int sockfd;

--- a/src/hash_drv.h
+++ b/src/hash_drv.h
@@ -88,7 +88,7 @@ typedef struct _hash_drv_map
   size_t			num_extents;
 } *hash_drv_map_t;
 
-struct _hash_drv_storage
+typedef struct _hash_drv_storage
 {
   hash_drv_map_t map;
   FILE *lock;

--- a/src/read_config.h
+++ b/src/read_config.h
@@ -37,6 +37,6 @@ config_t read_config (const char *path);
 int configure_algorithms (DSPAM_CTX * CTX);
 
 agent_pref_t pref_config(void);
-config_t agent_config;
+extern config_t agent_config;
 
 #endif /* _READ_CONFIG_H */

--- a/src/tools.hash_drv/utils.c
+++ b/src/tools.hash_drv/utils.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 
 #include "hash_drv.h"
 

--- a/src/tools/dspam_clean.c
+++ b/src/tools/dspam_clean.c
@@ -51,6 +51,7 @@
 #include "config_api.h"
 #include "pref.h"
 #include "error.h"
+#include "agent_shared.h"
 
 DSPAM_CTX *open_ctx = NULL, *open_mtx = NULL;
 


### PR DESCRIPTION
Replace definitions in header files by declarations. Move the definition to .c files.
Now it compiles with gcc 10.2.
